### PR TITLE
Add provider abstraction for Gemini and OpenAI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@google/genai": "^1.20.0",
         "dotenv": "^16.4.7",
+        "openai": "^5.22.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -1847,6 +1848,27 @@
       "integrity": "sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/openai": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.22.0.tgz",
+      "integrity": "sha512-uSsYZ+vw9JxUwnMTcT9bj5sGM5qY/4du2BIf1KSqDRZF9nhSlJYsBLPRwBZTOW+HNyjwGviR0SsoDPv5lpPrBw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@google/genai": "^1.20.0",
     "dotenv": "^16.4.7",
+    "openai": "^5.22.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },

--- a/server/http-error.ts
+++ b/server/http-error.ts
@@ -1,0 +1,9 @@
+export class HttpError extends Error {
+  public statusCode: number;
+
+  constructor(message: string, statusCode = 500) {
+    super(message);
+    this.name = 'HttpError';
+    this.statusCode = statusCode;
+  }
+}

--- a/server/prompts.ts
+++ b/server/prompts.ts
@@ -1,0 +1,2 @@
+export const SUGGESTIONS_PROMPT =
+  'Analise os traços faciais da pessoa nesta imagem (formato do rosto, testa, queixo, etc.). Com base nessa análise, sugira 3-4 estilos de penteado que a favoreceriam. Forneça uma breve justificativa (1-2 frases) para cada sugestão. Formate a resposta de forma clara e legível com títulos para cada estilo.';

--- a/server/providers/gemini.ts
+++ b/server/providers/gemini.ts
@@ -1,0 +1,141 @@
+import { GoogleGenAI, Modality, type GenerateContentResponse } from '@google/genai';
+
+import { HttpError } from '../http-error';
+import { SUGGESTIONS_PROMPT } from '../prompts';
+import type { ReferenceImagePayload } from '../types';
+
+export type GeminiProviderConfig = {
+  apiKey: string;
+  suggestionsModel: string;
+  imageModel: string;
+};
+
+export type GeminiProvider = {
+  name: 'Gemini';
+  generateSuggestions(base64Data: string, mimeType: string): Promise<string>;
+  generateHairstyle(
+    base64Data: string,
+    mimeType: string,
+    prompt: string,
+    referenceImage: ReferenceImagePayload | null
+  ): Promise<string>;
+};
+
+type GeminiContentPart = {
+  text?: string;
+  inlineData?: {
+    mimeType: string;
+    data: string;
+  };
+};
+
+export function createGeminiProvider(config: GeminiProviderConfig): GeminiProvider {
+  const ai = new GoogleGenAI({ apiKey: config.apiKey });
+
+  async function generateSuggestions(base64Data: string, mimeType: string): Promise<string> {
+    const userImagePart: GeminiContentPart = {
+      inlineData: {
+        data: base64Data,
+        mimeType,
+      },
+    };
+
+    const textPart: GeminiContentPart = {
+      text: SUGGESTIONS_PROMPT,
+    };
+
+    const response = await ai.models.generateContent({
+      model: config.suggestionsModel,
+      contents: { parts: [userImagePart, textPart] },
+    });
+
+    const suggestions = response.text;
+    if (!suggestions) {
+      throw new HttpError('A IA não retornou sugestões. Tente novamente em instantes.', 502);
+    }
+
+    return suggestions.trim();
+  }
+
+  async function generateHairstyle(
+    base64Data: string,
+    mimeType: string,
+    prompt: string,
+    referenceImage: ReferenceImagePayload | null
+  ): Promise<string> {
+    const userImagePart: GeminiContentPart = {
+      inlineData: {
+        data: base64Data,
+        mimeType,
+      },
+    };
+
+    const parts: GeminiContentPart[] = [userImagePart];
+    let finalPrompt = `Aplique este estilo de cabelo na pessoa da imagem: ${prompt}`;
+
+    if (referenceImage) {
+      const referencePart: GeminiContentPart = {
+        inlineData: {
+          data: referenceImage.base64Data,
+          mimeType: referenceImage.mimeType,
+        },
+      };
+
+      parts.push(referencePart);
+      const promptFallback = prompt.trim() || 'o estilo da imagem de referência';
+      finalPrompt = `Usando o penteado da segunda imagem como principal referência visual, aplique um estilo semelhante na pessoa da primeira imagem. Use a seguinte descrição como guia adicional: ${promptFallback}.`;
+    }
+
+    parts.push({ text: finalPrompt });
+
+    const response = await ai.models.generateContent({
+      model: config.imageModel,
+      contents: {
+        parts,
+      },
+      config: {
+        responseModalities: [Modality.IMAGE, Modality.TEXT],
+      },
+    });
+
+    if (response.promptFeedback?.blockReason) {
+      const { blockReason, blockReasonMessage } = response.promptFeedback;
+      const blockMessage = blockReasonMessage || blockReason || 'Solicitação bloqueada por motivos de segurança.';
+      throw new HttpError(`Sua solicitação foi bloqueada: ${blockMessage}`, 400);
+    }
+
+    const imagePart = findImagePart(response);
+    if (imagePart?.inlineData) {
+      return `data:${imagePart.inlineData.mimeType};base64,${imagePart.inlineData.data}`;
+    }
+
+    const textPart = findTextPart(response);
+    if (textPart?.text) {
+      throw new HttpError(`A IA retornou uma mensagem em vez de uma imagem: "${textPart.text}"`, 502);
+    }
+
+    console.error('Gemini API não retornou uma imagem utilizável.', JSON.stringify(response, null, 2));
+    throw new HttpError(
+      'A IA não conseguiu gerar uma imagem. Tente ajustar a descrição ou utilizar outra imagem de referência.',
+      502
+    );
+  }
+
+  return {
+    name: 'Gemini',
+    generateSuggestions,
+    generateHairstyle,
+  };
+}
+
+function findImagePart(response: GenerateContentResponse): GeminiContentPart | undefined {
+  return response.candidates?.[0]?.content?.parts?.find((part) => part.inlineData) as
+    | GeminiContentPart
+    | undefined;
+}
+
+function findTextPart(response: GenerateContentResponse): GeminiContentPart | undefined {
+  return response.candidates?.[0]?.content?.parts?.find((part) => part.text) as
+    | GeminiContentPart
+    | undefined;
+}

--- a/server/providers/openai.ts
+++ b/server/providers/openai.ts
@@ -1,0 +1,186 @@
+import OpenAI, { APIError } from 'openai';
+import type { ResponseOutputItem } from 'openai/resources/responses/responses';
+
+import { HttpError } from '../http-error';
+import { SUGGESTIONS_PROMPT } from '../prompts';
+import type { ReferenceImagePayload } from '../types';
+
+export type OpenAIProviderConfig = {
+  apiKey: string;
+  suggestionsModel: string;
+  imageModel: string;
+};
+
+export type OpenAIProvider = {
+  name: 'OpenAI';
+  generateSuggestions(base64Data: string, mimeType: string): Promise<string>;
+  generateHairstyle(
+    base64Data: string,
+    mimeType: string,
+    prompt: string,
+    referenceImage: ReferenceImagePayload | null
+  ): Promise<string>;
+};
+
+export function createOpenAIProvider(config: OpenAIProviderConfig): OpenAIProvider {
+  const client = new OpenAI({ apiKey: config.apiKey });
+
+  async function generateSuggestions(base64Data: string, mimeType: string): Promise<string> {
+    try {
+      const response = await client.responses.create({
+        model: config.suggestionsModel,
+        input: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'input_image',
+                image_url: toDataURL(base64Data, mimeType),
+                detail: 'auto',
+              },
+              {
+                type: 'input_text',
+                text: SUGGESTIONS_PROMPT,
+              },
+            ],
+          },
+        ],
+      });
+
+      if (response.error) {
+        throw new HttpError(`Sua solicitação foi rejeitada: ${response.error.message}`, 400);
+      }
+
+      const suggestions = response.output_text?.trim();
+      if (!suggestions) {
+        throw new HttpError('A IA não retornou sugestões. Tente novamente em instantes.', 502);
+      }
+
+      return suggestions;
+    } catch (error) {
+      handleOpenAIError(error);
+    }
+  }
+
+  async function generateHairstyle(
+    base64Data: string,
+    mimeType: string,
+    prompt: string,
+    referenceImage: ReferenceImagePayload | null
+  ): Promise<string> {
+    const content: Array<
+      | { type: 'input_image'; image_url: string; detail: 'low' | 'high' | 'auto' }
+      | { type: 'input_text'; text: string }
+    > = [
+      {
+        type: 'input_image',
+        image_url: toDataURL(base64Data, mimeType),
+        detail: 'high',
+      },
+    ];
+
+    let finalPrompt = `Aplique este estilo de cabelo na pessoa da imagem: ${prompt}`;
+
+    if (referenceImage) {
+      content.push({
+        type: 'input_image',
+        image_url: toDataURL(referenceImage.base64Data, referenceImage.mimeType),
+        detail: 'high',
+      });
+      const promptFallback = prompt.trim() || 'o estilo da imagem de referência';
+      finalPrompt = `Usando o penteado da segunda imagem como principal referência visual, aplique um estilo semelhante na pessoa da primeira imagem. Use a seguinte descrição como guia adicional: ${promptFallback}.`;
+    }
+
+    content.push({
+      type: 'input_text',
+      text: `${finalPrompt}. Gere apenas a nova imagem, sem texto adicional.`,
+    });
+
+    try {
+      const response = await client.responses.create({
+        model: config.suggestionsModel,
+        input: [
+          {
+            role: 'user',
+            content,
+          },
+        ],
+        tools: [
+          {
+            type: 'image_generation',
+            model: (config.imageModel || 'gpt-image-1') as 'gpt-image-1',
+            output_format: 'png',
+            background: 'auto',
+            input_fidelity: 'high',
+          },
+        ],
+      });
+
+      if (response.error) {
+        const status = response.error.code === 'rate_limit_exceeded' ? 429 : 400;
+        throw new HttpError(`Sua solicitação foi rejeitada: ${response.error.message}`, status);
+      }
+
+      const imageCall = findImageCall(response.output);
+      if (imageCall?.result) {
+        return `data:image/png;base64,${imageCall.result}`;
+      }
+
+      const textFallback = response.output_text?.trim();
+      if (textFallback) {
+        throw new HttpError(`A IA retornou uma mensagem em vez de uma imagem: "${textFallback}"`, 502);
+      }
+
+      throw new HttpError(
+        'A IA não conseguiu gerar uma imagem. Tente ajustar a descrição ou utilizar outra imagem de referência.',
+        502
+      );
+    } catch (error) {
+      handleOpenAIError(error);
+    }
+  }
+
+  return {
+    name: 'OpenAI',
+    generateSuggestions,
+    generateHairstyle,
+  };
+}
+
+function toDataURL(base64Data: string, mimeType: string): string {
+  return `data:${mimeType};base64,${base64Data}`;
+}
+
+function findImageCall(output: ResponseOutputItem[]): ResponseOutputItem.ImageGenerationCall | undefined {
+  return output.find((item): item is ResponseOutputItem.ImageGenerationCall => item.type === 'image_generation_call');
+}
+
+function handleOpenAIError(error: unknown): never {
+  if (error instanceof HttpError) {
+    throw error;
+  }
+
+  if (error instanceof APIError) {
+    const status = error.status ?? 502;
+
+    if (status === 401 || status === 403) {
+      throw new HttpError('Falha na autenticação com a OpenAI. Verifique a chave de API configurada.', status);
+    }
+
+    if (status === 429) {
+      throw new HttpError('A OpenAI está limitando requisições no momento. Tente novamente em instantes.', status);
+    }
+
+    if (status >= 400 && status < 500) {
+      throw new HttpError(error.message, status);
+    }
+
+    throw new HttpError('Erro ao gerar conteúdo com a OpenAI. Tente novamente mais tarde.', status);
+  }
+
+  if (error instanceof Error) {
+    throw new HttpError(error.message, 502);
+  }
+
+  throw error;
+}

--- a/server/types.ts
+++ b/server/types.ts
@@ -1,0 +1,4 @@
+export type ReferenceImagePayload = {
+  base64Data: string;
+  mimeType: string;
+};


### PR DESCRIPTION
## Summary
- add the official OpenAI SDK and expose configuration for selecting the active LLM provider
- extract the Gemini implementation into a provider module and add an equivalent OpenAI provider
- update the HTTP server to dispatch to the configured provider and expose neutral /api/llm routes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cda76221e08329b3754e792177fb40