### PR TITLE
Add configurable LLM provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,9 @@
-# Chave da API Gemini usada pelo backend
+# Chave da API do provedor Gemini usada pelo backend
 GEMINI_API_KEY=
+
+# Modelos padrão opcionais para o Gemini
+# GEMINI_IMAGE_MODEL=gemini-2.5-flash-image-preview
+# GEMINI_SUGGESTION_MODEL=gemini-2.5-flash
 
 # Porta opcional do servidor backend (padrão: 3001)
 # PORT=3001
@@ -9,3 +13,8 @@ GEMINI_API_KEY=
 
 # Base opcional utilizada pelo front-end para acessar o backend (padrão: /api)
 # VITE_API_BASE_URL=http://localhost:3001/api
+
+# Configurações padrão do LLM usadas pelo front-end (opcionais)
+# VITE_LLM_PROVIDER=gemini
+# VITE_LLM_MODEL=gemini-2.5-flash-image-preview
+# VITE_LLM_SUGGESTION_MODEL=gemini-2.5-flash

--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ GEMINI_API_KEY=
 # VITE_API_BASE_URL=http://localhost:3001/api
 
 # Configurações padrão do LLM usadas pelo front-end (opcionais)
+# VITE_LLM_PROVIDERS=gemini,openai
 # VITE_LLM_PROVIDER=gemini
 # VITE_LLM_MODEL=gemini-2.5-flash-image-preview
 # VITE_LLM_SUGGESTION_MODEL=gemini-2.5-flash

--- a/App.tsx
+++ b/App.tsx
@@ -119,7 +119,6 @@ const App: React.FC = () => {
       }
       const newSuggestions = await getHairstyleSuggestions(frame.base64Data, frame.mimeType, {
         provider: selectedProvider,
-        model: selectedGenerationModel,
         suggestionsModel: selectedSuggestionsModel,
       });
       setSuggestions(newSuggestions);

--- a/App.tsx
+++ b/App.tsx
@@ -20,7 +20,9 @@ const UNKNOWN_ERROR_MESSAGE = 'Ocorreu um erro desconhecido.';
 const NETWORK_ERROR_MESSAGE =
   'Não foi possível conectar ao servidor. Verifique sua conexão com a internet e se o backend está em execução.';
 
-const KNOWN_PROVIDER_OPTIONS = ['gemini'];
+const ENV_PROVIDER_OPTIONS = parseEnvList(import.meta.env?.VITE_LLM_PROVIDERS);
+const KNOWN_PROVIDER_OPTIONS =
+  ENV_PROVIDER_OPTIONS.length > 0 ? ENV_PROVIDER_OPTIONS : ['gemini'];
 const KNOWN_GENERATION_MODELS: Record<string, string[]> = {
   gemini: ['gemini-2.5-flash-image-preview', 'gemini-2.5-flash'],
 };
@@ -39,6 +41,19 @@ function uniqueList(...values: Array<string | undefined>): string[] {
   });
 
   return Array.from(unique);
+}
+
+function parseEnvList(value: string | undefined): string[] {
+  if (!value) {
+    return [];
+  }
+
+  return uniqueList(
+    ...value
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+  );
 }
 
 function formatProviderLabel(value: string): string {
@@ -129,7 +144,7 @@ const App: React.FC = () => {
     } finally {
       setIsSuggesting(false);
     }
-  }, [isLoading, isSuggesting, selectedGenerationModel, selectedProvider, selectedSuggestionsModel]);
+  }, [isLoading, isSuggesting, selectedProvider, selectedSuggestionsModel]);
 
   const handleGenerateHairstyle = useCallback(async () => {
     if (!cameraRef.current || isLoading || isSuggesting) return;

--- a/README.md
+++ b/README.md
@@ -4,26 +4,28 @@
 
 # Run and deploy your AI Studio app
 
-Esta aplicação React captura a imagem da webcam do usuário, envia para o backend e utiliza a API Gemini para sugerir penteados ou gerar uma prévia com um novo estilo.
+Esta aplicação React captura a imagem da webcam do usuário, envia para o backend e utiliza um provedor LLM configurável (por padrão, Google Gemini) para sugerir penteados ou gerar uma prévia com um novo estilo.
 
 ## Pré-requisitos
 - [Node.js](https://nodejs.org/) 18 ou superior
-- Uma chave válida da API Gemini
+- Uma chave válida do provedor LLM configurado (por padrão, Gemini)
 
 ## Configuração do ambiente
 1. Instale as dependências do projeto:
    ```bash
    npm install
    ```
-2. Copie o arquivo `.env.example` para `.env` e informe sua chave da API Gemini:
+2. Copie o arquivo `.env.example` para `.env` e informe as credenciais do provedor escolhido (por padrão, defina `GEMINI_API_KEY` para o Gemini):
    ```bash
    cp .env.example .env
-   # Edite o arquivo e defina GEMINI_API_KEY
+   # Edite o arquivo e defina as variáveis necessárias (ex.: GEMINI_API_KEY)
    ```
 3. Opcionalmente ajuste as variáveis de ambiente:
    - `PORT`: porta do servidor backend (padrão: `3001`).
    - `CORS_ORIGIN`: origem permitida para chamadas diretas ao backend.
+   - `GEMINI_IMAGE_MODEL` e `GEMINI_SUGGESTION_MODEL`: modelos padrão usados pelo backend quando o provedor é o Gemini.
    - `VITE_API_BASE_URL`: URL utilizada pelo front-end para chegar ao backend (padrão: `/api`, que é atendido via proxy do Vite).
+   - `VITE_LLM_PROVIDER`, `VITE_LLM_MODEL` e `VITE_LLM_SUGGESTION_MODEL`: valores padrão para exibição e envio ao backend.
 
 O backend lê automaticamente as variáveis definidas em `.env` através do pacote `dotenv`.
 
@@ -45,20 +47,20 @@ A aplicação estará disponível em `http://localhost:5173` e repassará as cha
 ## Endpoints do backend
 O servidor exposto em `server/index.ts` oferece as seguintes rotas HTTP:
 
-- `POST /api/gemini/suggestions`
-  - **Body**: `{ base64Data: string, mimeType: string }`
+- `POST /api/llm/suggestions`
+  - **Body**: `{ base64Data: string, mimeType: string, provider?: string, model?: string }`
   - **Resposta**: `{ suggestions: string }`
   - Retorna uma lista textual com sugestões de penteado para a imagem enviada.
 
-- `POST /api/gemini/edit`
-  - **Body**: `{ base64Data: string, mimeType: string, prompt: string, referenceImage?: { base64Data: string, mimeType: string } }`
-  - **Resposta**: `{ image: string }` (data URL contendo a imagem gerada).
-  - Gera uma nova imagem aplicando o estilo descrito (opcionalmente guiado por uma imagem de referência).
+- `POST /api/llm/edit`
+  - **Body**: `{ base64Data: string, mimeType: string, prompt: string, provider?: string, model?: string, referenceImage?: { base64Data: string, mimeType: string } }`
+  - **Resposta**: `{ image?: string, text?: string }` (data URL contendo a imagem gerada e/ou uma resposta textual).
+  - Gera uma nova imagem aplicando o estilo descrito (opcionalmente guiado por uma imagem de referência). Caso o provedor devolva somente texto, a mensagem é encaminhada ao front-end.
 
 - `GET /health`
   - Retorna `{"status":"ok"}` e pode ser usado para checagens simples de disponibilidade.
 
-Todas as rotas dependem da variável `GEMINI_API_KEY` e respondem em JSON. Erros são devolvidos com a propriedade `message` no corpo da resposta para facilitar o tratamento no front-end.
+Todas as rotas dependem de uma credencial válida (`GEMINI_API_KEY` quando o provedor ativo é o Gemini) e respondem em JSON. Erros são devolvidos com a propriedade `message` no corpo da resposta para facilitar o tratamento no front-end.
 
 ## Deploy
-Para implantar, disponibilize o backend como um serviço Node.js (executando `node --loader tsx server/index.ts` ou compilando para JavaScript) com a variável `GEMINI_API_KEY` configurada e sirva os arquivos do build do front-end gerados por `npm run build`. Ajuste `VITE_API_BASE_URL` conforme necessário para apontar para a URL pública do backend.
+Para implantar, disponibilize o backend como um serviço Node.js (executando `node --loader tsx server/index.ts` ou compilando para JavaScript) com as credenciais do provedor configuradas (ex.: `GEMINI_API_KEY`) e sirva os arquivos do build do front-end gerados por `npm run build`. Ajuste `VITE_API_BASE_URL` e as variáveis `VITE_LLM_*` conforme necessário para apontar para a URL pública do backend e selecionar o provedor/modelo desejado.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Esta aplicação React captura a imagem da webcam do usuário, envia para o back
    - `CORS_ORIGIN`: origem permitida para chamadas diretas ao backend.
    - `GEMINI_IMAGE_MODEL` e `GEMINI_SUGGESTION_MODEL`: modelos padrão usados pelo backend quando o provedor é o Gemini.
    - `VITE_API_BASE_URL`: URL utilizada pelo front-end para chegar ao backend (padrão: `/api`, que é atendido via proxy do Vite).
+   - `VITE_LLM_PROVIDERS`: lista de provedores exibidos no seletor do front-end (separados por vírgula). Se omitido, apenas o provedor padrão é mostrado.
    - `VITE_LLM_PROVIDER`, `VITE_LLM_MODEL` e `VITE_LLM_SUGGESTION_MODEL`: valores padrão para exibição e envio ao backend.
 
 O backend lê automaticamente as variáveis definidas em `.env` através do pacote `dotenv`.
@@ -56,6 +57,8 @@ O servidor exposto em `server/index.ts` oferece as seguintes rotas HTTP:
   - **Body**: `{ base64Data: string, mimeType: string, prompt: string, provider?: string, model?: string, referenceImage?: { base64Data: string, mimeType: string } }`
   - **Resposta**: `{ image?: string, text?: string }` (data URL contendo a imagem gerada e/ou uma resposta textual).
   - Gera uma nova imagem aplicando o estilo descrito (opcionalmente guiado por uma imagem de referência). Caso o provedor devolva somente texto, a mensagem é encaminhada ao front-end.
+
+- Rotas legadas `/api/gemini/suggestions` e `/api/gemini/edit` continuam disponíveis e encaminham para os mesmos fluxos acima, garantindo compatibilidade com integrações existentes.
 
 - `GET /health`
   - Retorna `{"status":"ok"}` e pode ser usado para checagens simples de disponibilidade.

--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useId, useRef } from 'react';
 import { PhotoIcon, XCircleIcon, LightBulbIcon } from './Icons';
 
 interface ControlsProps {
@@ -12,11 +12,45 @@ interface ControlsProps {
     onImageUpload: (event: React.ChangeEvent<HTMLInputElement>) => void;
     referenceImage: string | null;
     onRemoveReferenceImage: () => void;
+    provider: string;
+    providerOptions: string[];
+    onProviderChange: (provider: string) => void;
+    suggestionsModel: string;
+    suggestionsModelOptions: string[];
+    onSuggestionsModelChange: (model: string) => void;
+    generationModel: string;
+    generationModelOptions: string[];
+    onGenerationModelChange: (model: string) => void;
 }
 
-export const Controls: React.FC<ControlsProps> = ({ prompt, setPrompt, onSubmit, onSuggest, isLoading, buttonIcon, buttonText, onImageUpload, referenceImage, onRemoveReferenceImage }) => {
-    
+export const Controls: React.FC<ControlsProps> = ({
+    prompt,
+    setPrompt,
+    onSubmit,
+    onSuggest,
+    isLoading,
+    buttonIcon,
+    buttonText,
+    onImageUpload,
+    referenceImage,
+    onRemoveReferenceImage,
+    provider,
+    providerOptions,
+    onProviderChange,
+    suggestionsModel,
+    suggestionsModelOptions,
+    onSuggestionsModelChange,
+    generationModel,
+    generationModelOptions,
+    onGenerationModelChange,
+}) => {
+
     const fileInputRef = useRef<HTMLInputElement>(null);
+    const uniqueId = useId().replace(/:/g, '');
+    const generationDatalistId = `llm-generation-${uniqueId}`;
+    const suggestionsDatalistId = `llm-suggestions-${uniqueId}`;
+    const suggestionsModelLabel = suggestionsModel.trim() || 'padrão do servidor';
+    const generationModelLabel = generationModel.trim() || 'padrão do servidor';
 
     const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
         if (event.key === 'Enter' && !isLoading && (prompt.trim() || referenceImage)) {
@@ -30,11 +64,73 @@ export const Controls: React.FC<ControlsProps> = ({ prompt, setPrompt, onSubmit,
 
     return (
         <div className="w-full flex flex-col gap-4">
+            <div className="w-full bg-gray-800/70 border border-gray-700 rounded-xl p-4 flex flex-col gap-3">
+                <div className="w-full grid grid-cols-1 sm:grid-cols-3 gap-3">
+                    <label className="flex flex-col gap-1 text-sm text-gray-300">
+                        <span className="text-xs font-semibold uppercase tracking-wide text-gray-400">Provedor</span>
+                        <select
+                            value={provider}
+                            onChange={(event) => onProviderChange(event.target.value)}
+                            disabled={isLoading}
+                            className="bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-purple-500 disabled:opacity-70"
+                        >
+                            {providerOptions.map((option) => (
+                                <option key={option} value={option}>
+                                    {formatProviderLabel(option)}
+                                </option>
+                            ))}
+                        </select>
+                    </label>
+                    <label className="flex flex-col gap-1 text-sm text-gray-300">
+                        <span className="text-xs font-semibold uppercase tracking-wide text-gray-400">Modelo para sugestões</span>
+                        <input
+                            type="text"
+                            value={suggestionsModel}
+                            onChange={(event) => onSuggestionsModelChange(event.target.value)}
+                            disabled={isLoading}
+                            list={suggestionsModelOptions.length > 0 ? suggestionsDatalistId : undefined}
+                            placeholder="Ex.: gemini-2.5-flash"
+                            className="bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-purple-500 disabled:opacity-70"
+                        />
+                        {suggestionsModelOptions.length > 0 && (
+                            <datalist id={suggestionsDatalistId}>
+                                {suggestionsModelOptions.map((option) => (
+                                    <option key={option} value={option} />
+                                ))}
+                            </datalist>
+                        )}
+                    </label>
+                    <label className="flex flex-col gap-1 text-sm text-gray-300">
+                        <span className="text-xs font-semibold uppercase tracking-wide text-gray-400">Modelo para geração de imagem</span>
+                        <input
+                            type="text"
+                            value={generationModel}
+                            onChange={(event) => onGenerationModelChange(event.target.value)}
+                            disabled={isLoading}
+                            list={generationModelOptions.length > 0 ? generationDatalistId : undefined}
+                            placeholder="Ex.: gemini-2.5-flash-image-preview"
+                            className="bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-purple-500 disabled:opacity-70"
+                        />
+                        {generationModelOptions.length > 0 && (
+                            <datalist id={generationDatalistId}>
+                                {generationModelOptions.map((option) => (
+                                    <option key={option} value={option} />
+                                ))}
+                            </datalist>
+                        )}
+                    </label>
+                </div>
+                <p className="text-xs text-gray-400">
+                    Usando <span className="text-gray-200">{formatProviderLabel(provider)}</span> com modelos
+                    <span className="text-gray-200"> {suggestionsModelLabel}</span> (sugestões) e
+                    <span className="text-gray-200"> {generationModelLabel}</span> (geração).
+                </p>
+            </div>
             <div className="w-full flex items-center gap-3">
                 {referenceImage ? (
                     <div className="relative flex-shrink-0">
                         <img src={referenceImage} alt="Imagem de referência" className="w-14 h-14 rounded-lg object-cover border-2 border-purple-500" />
-                        <button 
+                        <button
                             onClick={onRemoveReferenceImage}
                             className="absolute -top-2 -right-2 bg-gray-800 rounded-full text-white hover:text-red-400 transition-colors"
                             aria-label="Remover imagem de referência"
@@ -93,3 +189,15 @@ export const Controls: React.FC<ControlsProps> = ({ prompt, setPrompt, onSubmit,
         </div>
     );
 };
+
+function formatProviderLabel(value: string): string {
+    if (!value) {
+        return 'Padrão do servidor';
+    }
+
+    return value
+        .split(/[-_]/)
+        .filter(Boolean)
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(' ');
+}

--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -133,9 +133,9 @@ export const Controls: React.FC<ControlsProps> = ({
                     </label>
                 </div>
                 <p className="text-xs text-gray-400">
-                    Usando <span className="text-gray-200">{formatProviderLabel(provider)}</span> com modelos
-                    <span className="text-gray-200"> {suggestionsModelLabel}</span> (sugestões) e
-                    <span className="text-gray-200"> {generationModelLabel}</span> (geração).
+                    Usando <span className="text-gray-200">{formatProviderLabel(provider)}</span> com modelos{' '}
+                    <span className="text-gray-200">{suggestionsModelLabel}</span> (sugestões) e{' '}
+                    <span className="text-gray-200">{generationModelLabel}</span> (geração).
                 </p>
             </div>
             <div className="w-full flex items-center gap-3">

--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -23,6 +23,16 @@ interface ControlsProps {
     onGenerationModelChange: (model: string) => void;
 }
 
+const MODEL_PLACEHOLDER_EXAMPLES: Record<string, { suggestions: string; generation: string }> = {
+    gemini: {
+        suggestions: 'Ex.: gemini-2.5-flash',
+        generation: 'Ex.: gemini-2.5-flash-image-preview',
+    },
+};
+
+const FALLBACK_SUGGESTION_PLACEHOLDER = 'Ex.: modelo preferido para sugestões';
+const FALLBACK_GENERATION_PLACEHOLDER = 'Ex.: modelo preferido para imagens';
+
 export const Controls: React.FC<ControlsProps> = ({
     prompt,
     setPrompt,
@@ -51,6 +61,8 @@ export const Controls: React.FC<ControlsProps> = ({
     const suggestionsDatalistId = `llm-suggestions-${uniqueId}`;
     const suggestionsModelLabel = suggestionsModel.trim() || 'padrão do servidor';
     const generationModelLabel = generationModel.trim() || 'padrão do servidor';
+    const suggestionsPlaceholder = getModelPlaceholder(provider, 'suggestions');
+    const generationPlaceholder = getModelPlaceholder(provider, 'generation');
 
     const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
         if (event.key === 'Enter' && !isLoading && (prompt.trim() || referenceImage)) {
@@ -89,7 +101,7 @@ export const Controls: React.FC<ControlsProps> = ({
                             onChange={(event) => onSuggestionsModelChange(event.target.value)}
                             disabled={isLoading}
                             list={suggestionsModelOptions.length > 0 ? suggestionsDatalistId : undefined}
-                            placeholder="Ex.: gemini-2.5-flash"
+                            placeholder={suggestionsPlaceholder}
                             className="bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-purple-500 disabled:opacity-70"
                         />
                         {suggestionsModelOptions.length > 0 && (
@@ -108,7 +120,7 @@ export const Controls: React.FC<ControlsProps> = ({
                             onChange={(event) => onGenerationModelChange(event.target.value)}
                             disabled={isLoading}
                             list={generationModelOptions.length > 0 ? generationDatalistId : undefined}
-                            placeholder="Ex.: gemini-2.5-flash-image-preview"
+                            placeholder={generationPlaceholder}
                             className="bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-purple-500 disabled:opacity-70"
                         />
                         {generationModelOptions.length > 0 && (
@@ -200,4 +212,17 @@ function formatProviderLabel(value: string): string {
         .filter(Boolean)
         .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
         .join(' ');
+}
+
+function getModelPlaceholder(provider: string, type: 'suggestions' | 'generation'): string {
+    const normalizedProvider = provider.trim().toLowerCase();
+    const examples = MODEL_PLACEHOLDER_EXAMPLES[normalizedProvider];
+
+    if (examples) {
+        return examples[type];
+    }
+
+    return type === 'suggestions'
+        ? FALLBACK_SUGGESTION_PLACEHOLDER
+        : FALLBACK_GENERATION_PLACEHOLDER;
 }

--- a/env.d.ts
+++ b/env.d.ts
@@ -2,6 +2,9 @@
 
 declare interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
+  readonly VITE_LLM_PROVIDER?: string;
+  readonly VITE_LLM_MODEL?: string;
+  readonly VITE_LLM_SUGGESTION_MODEL?: string;
 }
 
 declare interface ImportMeta {

--- a/env.d.ts
+++ b/env.d.ts
@@ -2,6 +2,7 @@
 
 declare interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
+  readonly VITE_LLM_PROVIDERS?: string;
   readonly VITE_LLM_PROVIDER?: string;
   readonly VITE_LLM_MODEL?: string;
   readonly VITE_LLM_SUGGESTION_MODEL?: string;

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Provador de Penteados com IA",
-  "description": "Uma aplicação web que usa sua câmera e o poder do Gemini para permitir que você experimente diferentes penteados. Basta descrever um penteado ou enviar uma imagem de referência e ver o resultado em sua foto.",
+  "description": "Uma aplicação web que usa sua câmera e o poder de um provedor LLM configurável para permitir que você experimente diferentes penteados. Basta descrever um penteado ou enviar uma imagem de referência e ver o resultado em sua foto.",
   "requestFramePermissions": [
     "camera"
   ]


### PR DESCRIPTION
## Summary
- replace the Gemini-specific service with a generic LLM client that reads provider and model defaults from environment variables and talks to `/api/llm` routes
- expose provider and model controls in the main UI, handle text-only responses, and surface the active configuration throughout the app
- generalize the backend endpoints and documentation to accept provider/model parameters while returning both image and text outputs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cda77a689883298e00ac0f77cbcd51